### PR TITLE
Specify the Activity ID

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,11 @@
         
         ADL.XAPIWrapper.changeConfig(conf);       
     }
+
+    // Force the player to use a specific IRI as the activity ID. 
+    // If not, the player uses the video source URL.
+    // var activityId = "http://here-is-my-video-activity-iri";
+
     // put into variables - title and description from the metadata DIV above the video element 
     var activityTitle = document.getElementById('vidtitle').getAttribute('content');
     var activityDesc = document.getElementById('viddesc').getAttribute('content');  

--- a/xapi-videojs.js
+++ b/xapi-videojs.js
@@ -7,7 +7,7 @@
 
         // Global Variables & common functions
         var myPlayer = videojs(target);
-        var objectID = myPlayer.currentSrc().toString();
+        var objectID = typeof activityId !== 'undefined' ? activityId : myPlayer.currentSrc().toString();
         var sessionID = ADL.ruuid();
         var skipPlayEvent = false;
         var sendCCSubtitle = false;


### PR DESCRIPTION
Currently, the video source URL is used to set the statements object ID.

Now people can define their own activity ID in their JS code: `var activityId = "http://here-is-my-video-activity-iri";`